### PR TITLE
Minor Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,19 +64,18 @@ install:
   - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
   - STEAMCOMMON_DIR="${TRAVIS_BUILD_DIR}/steam_common"
   - mkdir -p ${DEPS_DIR} && mkdir -p ${STEAMCOMMON_DIR} && mkdir -p ${STEAMCOMMON_DIR} && mkdir -p ${STEAMCOMMON_DIR}/Half-Life && cd ${DEPS_DIR}
-  # Make symlinks so it can use vgui properly.
-  - ln -s ${TRAVIS_BUILD_DIR}/lib/public/vgui.so ${STEAMCOMMON_DIR}/Half-Life/vgui.so
-  - ln -s ${TRAVIS_BUILD_DIR}/lib/public/vgui.dylib ${STEAMCOMMON_DIR}/Half-Life/vgui.dylib
-  # Get the latest CMake version
+  # Get the latest CMake version and Make symlinks so it can use VGUI properly
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       CMAKE_URL="http://www.cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
+      ln -s ${TRAVIS_BUILD_DIR}/lib/public/vgui.so ${STEAMCOMMON_DIR}/Half-Life/vgui.so
     else
       CMAKE_URL="http://www.cmake.org/files/v3.7/cmake-3.7.2-Darwin-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/CMake.app/Contents/bin:${PATH}
+      ln -s ${TRAVIS_BUILD_DIR}/lib/public/vgui.dylib ${STEAMCOMMON_DIR}/Half-Life/vgui.dylib
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,11 +70,11 @@ install:
   # Get the latest CMake version
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="http://www.cmake.org/files/v3.6/cmake-3.6.2-Linux-x86_64.tar.gz"
+      CMAKE_URL="http://www.cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
     else
-      CMAKE_URL="http://www.cmake.org/files/v3.6/cmake-3.6.2-Darwin-x86_64.tar.gz"
+      CMAKE_URL="http://www.cmake.org/files/v3.7/cmake-3.7.2-Darwin-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/CMake.app/Contents/bin:${PATH}
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
 # Use the C base
 language: c
 
-# Linux - use Ubuntu 14.04 Trusty Tahr instead of 12.04 Precise Pengolin, this
-# is required for the correct version of libsdl2-dev.
+# Linux - use Ubuntu 14.04 Trusty Tahr instead of 12.04 Precise Pengolin.
 sudo: required
 dist: trusty
 
-# Linux - add the Ubuntu restricted tool chain to install GCC 6 and SDL2's dev
-# package
+# Linux - add the Ubuntu restricted tool chain to install GCC 6 package
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - libsdl2-dev
     - linux-libc-dev
     - gcc-6-multilib
     - g++-6-multilib


### PR DESCRIPTION
This PR bump CMake versions and move the symbolic links to VGUI in the proper OS conditions (no need to link a DYLIB under Linux).

EDIT: We don't need libsdl2-dev too so I removed it