### PR TITLE
Improve various areas of GitHub pages

### DIFF
--- a/about.htm
+++ b/about.htm
@@ -7,68 +7,66 @@
 		<meta http-equiv="X-UA-compatible" content="IE=edge">
 
 		<!-- Bootstrap 4 CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 		<link rel="stylesheet" href="design.css">
 
 		<title>Half-Life: Enhanced - About</title>
 	</head>
-		<body>
-
-			<!-- Navigation bar -->
-			<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
-				<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
-				<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-				<div class="collapse navbar-toggleable-md" id="navbarResponsive">
-					<ul class="nav navbar-nav">
-						<li class="nav-item">
-							<a class="nav-link" href="index.htm">Home</a>
-						</li>
-						<li class="nav-item active">
-							<a class="nav-link" href="#">About <span class="sr-only">(current)</span></a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="downloads.htm">Downloads</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="documentation.htm">Documentation</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="social.htm">Social</a>
-						</li>
-					</ul>
-				</div>
-			</nav>
-
-			<!-- Breadcrumb -->
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item active">About</li>
-			</ol>
-
-			<!-- Content -->
-			<div class="container">
-				<div class="starter-template">
-					<h1>About</h1>
-					<p class="lead">Giving Half-Life 1 the love it deserves.</p>
-
-					<p>Half-Life: Enhanced is a project that give more power to <a href="http://store.steampowered.com/app/70/">Half-Life 1</a> modders for their creations.<br>
-					The main features are cleaning Valve's code, provide better documentation (powered by <a href="http://www.stack.nl/~dimitri/doxygen/">Doxygen</a>), bugs/crash fixes and a lot of <a href="https://github.com/SamVanheer/HLEnhanced/wiki/Features">new features</a>.<br>
-					Thanks to the open source model, anyone regardless of Half-Life 1 modding experience can contribute to the project.<br>
-					Half-Life: Enhanced is a project created by <a href="https://github.com/SamVanheer">Solokiller</a>.</p>
-
-				</div>
+	<body>
+		<!-- Navigation bar -->
+		<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+			<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
+			<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
+			<div class="collapse navbar-toggleable-md" id="navbarResponsive">
+				<ul class="nav navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link" href="index.htm">Home</a>
+					</li>
+					<li class="nav-item active">
+						<a class="nav-link" href="#">About <span class="sr-only">(current)</span></a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="downloads.htm">Downloads</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="documentation.htm">Documentation</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="social.htm">Social</a>
+					</li>
+				</ul>
 			</div>
+		</nav>
 
-			<!-- Footer -->
-			<footer class="footer">
-				<div class="container">
-					<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
-					Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
-				</div>
-			</footer>
+		<!-- Breadcrumb -->
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item active">About</li>
+		</ol>
 
-			<!-- Bootstrap 4 JS -->
-			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
-			<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
-			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+		<!-- Content -->
+		<div class="container">
+			<div class="starter-template">
+				<h1>About</h1>
+				<p class="lead">Giving Half-Life 1 the love it deserves.</p>
+
+				<p>Half-Life: Enhanced is a project that give more power to <a href="http://store.steampowered.com/app/70/">Half-Life 1</a> modders for their creations and bring a lot of fixes and improvements for the players as well.<br>
+				The main features are cleaning Valve's code, provide better documentation (powered by <a href="http://www.stack.nl/~dimitri/doxygen/">Doxygen</a>), fix bugs and crashes and much more that you can check in the <a href="https://github.com/SamVanheer/HLEnhanced/wiki/Features">"Features" page of the wiki</a>.<br>
+				Thanks to the open source model, anyone regardless of Half-Life 1 modding experience can contribute to the project.<br>
+				Half-Life: Enhanced is a project created by <a href="https://github.com/SamVanheer">Solokiller</a> with contributions from Half-Life 1 fans from all over the world.</p>
+			</div>
+		</div>
+
+		<!-- Footer -->
+		<footer class="footer">
+			<div class="container">
+				<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
+				Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
+			</div>
+		</footer>
+
+		<!-- Bootstrap 4 JS -->
+		<script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 	</body>
 </html>

--- a/design.css
+++ b/design.css
@@ -12,7 +12,10 @@ body {
 	width: 100%;
 	/* Set the fixed height of the footer here */
 	height: 60px;
-	line-height: 30px; /* Vertically center the text there */ /* Shepard : Leave some space for the HL1 copyright notice. */
-	background-color: #f5f5f5;
+	line-height: 30px; /* Vertically center the text there - Shepard : Leave some space for the HL1 copyright notice. */
+	background-color: #F5F5F5;
 	font-size: 12px; /* Shepard : reduce the text size for mobiles */
+}
+button a {
+	color: #FFFFFF;
 }

--- a/documentation.htm
+++ b/documentation.htm
@@ -7,84 +7,83 @@
 		<meta http-equiv="X-UA-compatible" content="IE=edge">
 
 		<!-- Bootstrap 4 CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 		<link rel="stylesheet" href="design.css">
 
 		<title>Half-Life: Enhanced - Documentation</title>
 	</head>
-		<body>
-
-			<!-- Navigation bar -->
-			<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
-				<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
-				<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-				<div class="collapse navbar-toggleable-md" id="navbarResponsive">
-					<ul class="nav navbar-nav">
-						<li class="nav-item">
-							<a class="nav-link" href="index.htm">Home</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="about.htm">About</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="downloads.htm">Downloads</a>
-						</li>
-						<li class="nav-item active">
-							<a class="nav-link" href="#">Documentation <span class="sr-only">(current)</span></a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="social.htm">Social</a>
-						</li>
-					</ul>
-				</div>
-			</nav>
-
-			<!-- Breadcrumb -->
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item active">Documentation</li>
-			</ol>
-
-			<!-- Content -->
-			<div class="container">
-				<div class="starter-template">
-					<h1>Documentation</h1>
-					<p class="lead">Learn how to work with Half-Life: Enhanced to empower your Half-Life 1 mods and maps.</p>
-
-					<h2>Half-Life: Enhanced's documentation</h2>
-					<ul class="list-group">
-						<li class="list-group-item"><a href="docs/index.html">Doxygen (for programmers)</a></li>
-						<li class="list-group-item"><a href="https://github.com/SamVanheer/HLEnhanced/wiki">GitHub's wiki</a></li>
-					</ul>
-
-					<p><!-- This is evil --></p>
-
-					<h2>Other documentation</h2>
-					<ul class="list-group">
-						<li class="list-group-item"><a href="http://www.angelcode.com/angelscript/sdk/docs/manual/">Angelscript's documentation (the scripting engine used within Half-Life Enhanced)</a></li>
-						<li class="list-group-item"><a href="http://forums.svencoop.com/showthread.php/43228-A-very-technical-explanation-regarding-the-engine">Solokiller's technical explanation of the Half-Life 1 engine on Sven Coop forums</a></li>
-						<li class="list-group-item"><a href="http://twhl.info/wiki.php?sub=1">The Whole Half-Life's entity guide (all Half-Life 1 entities detailed)</a></li>
-						<li class="list-group-item"><a href="http://twhl.info/tutorial.php?cat=1">The Whole Half-Life's tutorials (most of them cover Half-Life 1 mapping and programming)</a></li>
-						<li class="list-group-item"><a href="http://twhl.info/articulator.php">The Whole Half-Life's VERC archive</a></li>
-					</ul>
-
-					<p>You want to add your own or other documentation related to Half-Life: Enhanced and/or Half-Life 1 modding that could be interesting? Feel free to add it through GitHub!</p>
-
-					<p><br><!-- This is evil --></p>
-
-				</div>
+	<body>
+		<!-- Navigation bar -->
+		<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+			<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
+			<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
+			<div class="collapse navbar-toggleable-md" id="navbarResponsive">
+				<ul class="nav navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link" href="index.htm">Home</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="about.htm">About</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="downloads.htm">Downloads</a>
+					</li>
+					<li class="nav-item active">
+						<a class="nav-link" href="#">Documentation <span class="sr-only">(current)</span></a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="social.htm">Social</a>
+					</li>
+				</ul>
 			</div>
+		</nav>
 
-			<!-- Footer -->
-			<footer class="footer">
-				<div class="container">
-					<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
-					Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
-				</div>
-			</footer>
+		<!-- Breadcrumb -->
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item active">Documentation</li>
+		</ol>
 
-			<!-- Bootstrap 4 JS -->
-			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
-			<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
-			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+		<!-- Content -->
+		<div class="container">
+			<div class="starter-template">
+				<h1>Documentation</h1>
+				<p class="lead">Learn how to work with Half-Life: Enhanced to empower your Half-Life 1 mods and maps.</p>
+
+				<h2>Half-Life: Enhanced's documentation</h2>
+				<ul class="list-group">
+					<li class="list-group-item"><a href="docs/index.html">Doxygen (for programmers) - maybe be outdated</a></li>
+					<li class="list-group-item"><a href="https://github.com/SamVanheer/HLEnhanced/wiki">GitHub's wiki</a></li>
+				</ul>
+
+				<p><!-- This is evil --></p>
+
+				<h2>Other documentation</h2>
+				<ul class="list-group">
+					<li class="list-group-item"><a href="https://github.com/SamVanheer/GoldSourceRebuild">Gold Source Rebuild @ GitHub - A work in progress reversed engineered version of the Gold Source engine by Solokiller</a></li>
+					<li class="list-group-item"><a href="http://www.angelcode.com/angelscript/sdk/docs/manual/">Angelscript's documentation (the scripting engine used within Half-Life Enhanced)</a></li>
+					<li class="list-group-item"><a href="http://forums.svencoop.com/showthread.php/43228-A-very-technical-explanation-regarding-the-engine">Solokiller's technical explanation of the Half-Life 1 engine on Sven Coop forums</a></li>
+					<li class="list-group-item"><a href="http://twhl.info/wiki.php?sub=1">The Whole Half-Life's entity guide (all Half-Life 1 entities detailed)</a></li>
+					<li class="list-group-item"><a href="http://twhl.info/tutorial.php?cat=1">The Whole Half-Life's tutorials (most of them cover Half-Life 1 mapping and programming)</a></li>
+					<li class="list-group-item"><a href="http://twhl.info/articulator.php">The Whole Half-Life's VERC archive</a></li>
+				</ul>
+
+				<p>You want to add your own or other documentation related to Half-Life: Enhanced and/or Half-Life 1 modding that could be interesting? Feel free to add it through GitHub!</p>
+
+				<p><br><!-- This is evil --></p>
+			</div>
+		</div>
+
+		<!-- Footer -->
+		<footer class="footer">
+			<div class="container">
+				<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
+				Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
+			</div>
+		</footer>
+
+		<!-- Bootstrap 4 JS -->
+		<script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 	</body>
 </html>

--- a/downloads.htm
+++ b/downloads.htm
@@ -7,98 +7,96 @@
 		<meta http-equiv="X-UA-compatible" content="IE=edge">
 
 		<!-- Bootstrap 4 CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 		<link rel="stylesheet" href="design.css">
 
 		<title>Half-Life: Enhanced - Downloads</title>
 	</head>
-		<body>
+	<body>
+		<!-- Navigation bar -->
+		<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+			<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
+			<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
+			<div class="collapse navbar-toggleable-md" id="navbarResponsive">
+				<ul class="nav navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link" href="index.htm">Home</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="about.htm">About</a>
+					</li>
+					<li class="nav-item active">
+						<a class="nav-link" href="#">Downloads <span class="sr-only">(current)</span></a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="documentation.htm">Documentation</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="social.htm">Social</a>
+					</li>
+				</ul>
+			</div>
+		</nav>
 
-			<!-- Navigation bar -->
-			<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
-				<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
-				<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-				<div class="collapse navbar-toggleable-md" id="navbarResponsive">
-					<ul class="nav navbar-nav">
-						<li class="nav-item">
-							<a class="nav-link" href="index.htm">Home</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="about.htm">About</a>
-						</li>
-						<li class="nav-item active">
-							<a class="nav-link" href="#">Downloads <span class="sr-only">(current)</span></a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="documentation.htm">Documentation</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="social.htm">Social</a>
-						</li>
-					</ul>
-				</div>
-			</nav>
+		<!-- Breadcrumb -->
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item active">Downloads</li>
+		</ol>
 
-			<!-- Breadcrumb -->
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item active">Downloads</li>
-			</ol>
+		<!-- Content -->
+		<div class="container">
+			<div class="starter-template">
+				<h1>Downloads</h1>
+				<p class="lead">Ready to empower your Half-Life 1? Download Half-Life: Enhanced now!</p>
 
-			<!-- Content -->
-			<div class="container">
-				<div class="starter-template">
-					<h1>Downloads</h1>
-					<p class="lead">Ready to empower your Half-Life 1 modding capabilities? Download Half-Life: Enhanced now!</p>
+				<h2>Requirements</h2>
+				<p>If you are planning on just using Half-Life: Enhanced, then you must have the <a href="http://store.steampowered.com/about/">Steam</a> client installed and own a Steam account with a <a href="http://store.steampowered.com/app/70/">Half-Life 1</a> license. Steam must report that Half-Life 1 is <strong>"Ready to play"</strong>. If you are planning to change/compile the source code, you might want to read the <a href="https://github.com/SamVanheer/HLEnhanced/wiki/Compiling">"Compiling"</a> page on the <a href="https://github.com/SamVanheer/HLEnhanced/wiki">wiki</a>. Half-Life: Enhanced may have compatibilities issues with other Gold Source engines like WON and Xash3D so extra caution is needed when using those engines.</p>
 
-					<h2>Requirements</h2>
-					<p>If you are planning on just using Half-Life: Enhanced, then you must have the <a href="http://store.steampowered.com/about/">Steam</a> client installed and own a Steam account with a <a href="http://store.steampowered.com/app/70/">Half-Life 1</a> license. Steam must report that Half-Life 1 is <strong>"Ready to play"</strong>. If you are planning to change/compile the source code, you might want to read the <a href="https://github.com/SamVanheer/HLEnhanced/wiki/Compiling">"Compiling"</a> page on <a href="https://github.com/SamVanheer/HLEnhanced/wiki">wiki</a>.</p>
+				<h2>Instructions</h2>
+				<p>Select the version you want to use below, download the "Game" data by clicking on it's button. Extract the <em>"hlenhanced"</em> folder in your Half-Life installation and restart Steam if necessary. If you are a programmer, you can download the source code by clicking on it's button.<br>
+				<br>
+				<em>Note:</em> all downloads are automatically generated. If you want to share any download, please post a link to this page instead of the direct downloads, thank you.</p>
 
-					<h2>Instructions</h2>
-					<p>Select the version you want to use below, download the "Game" data by clicking on it's button. Extract the <em>"hlenhanced"</em> folder in your Half-Life installation. If you are a programmer, you can download the source code by clicking on it's button.<br>
-					<br>
-					<em>Note:</em> all downloads are automatically generated. If you want to share any download, please post a link to this page instead of the direct downloads, thank you.</p>
-
-					<div class="row">
-						<!-- Stable -->
-						<div class="col-xs-6">
-							<h3>Stable</h3>
-							<p>Stable versions have received a lot of testing, bug/crash fixes and features. They may get outdated quickly against the "Snapshot" and "Bleeding Edge" versions but if you are looking to create/upgrade your Half-Life 1 map/mod project, this is definetely the version you should use.</p>
-							<button type="button" class="btn btn-success"><a href="#" style="color: #FFFFFF;">Game - Coming soon</a></button>
-							<button type="button" class="btn btn-success"><a href="#" style="color: #FFFFFF;">Source code - Coming soon</a></button>
-						</div>
-
-						<!-- Snapshot -->
-						<div class="col-xs-6">
-							<h3>Snapshot</h3>
-							<p>Snapshots versions contains more features but may not be stable as the "Stable" versions. If you are looking to test Half-Life: Enhanced to report bugs and/or you are not afraid of using a version that may contains bugs, then go ahead.</p>
-							<button type="button" class="btn btn-warning"><a href="#" style="color: #FFFFFF;">Game - Coming soon</a></button>
-							<button type="button" class="btn btn-warning"><a href="#" style="color: #FFFFFF;">Source code - Coming soon</a></button>
-						</div>
+				<div class="row">
+					<!-- Stable -->
+					<div class="col-xs-6">
+						<h3>Stable</h3>
+						<p>Stable versions have received a lot of testing, fixes for crashes and bugs and features. They may get outdated quickly against the "Snapshot" and "Bleeding Edge" versions but if you are looking to create or upgrade your Half-Life 1 map or mod project, this is definetely the version you should use.</p>
+						<button type="button" class="btn btn-success"><a href="#">Game - Coming soon</a></button>
+						<button type="button" class="btn btn-success"><a href="#">Source code - Coming soon</a></button>
 					</div>
 
-					<p><!-- This is evil --></p>
-
-					<h2>Bleeding Edge</h3>
-					<p>If you want to get the very latest features and/or contribute to Half-Life: Enhanced, this is the version you should use. Keep in mind that this version is likely to contain a lot of bugs and eventually crash. If you are looking to create/upgrade your Half-Life 1 map/mod project, we highly recommend to <b>NOT</b> use this version.</p>
-					<button type="button" class="btn btn-danger"><a href="https://github.com/SamVanheer/HLEnhanced-Game" style="color: #FFFFFF;">Game - GitHub</a></button>
-					<button type="button" class="btn btn-danger"><a href="https://github.com/SamVanheer/HLEnhanced" style="color: #FFFFFF;">Source code - GitHub</a></button>
-
-					<p><!-- This is evil --></p>
-
+					<!-- Snapshot -->
+					<div class="col-xs-6">
+						<h3>Snapshot</h3>
+						<p>Snapshots versions contains more features but may not be very stable like the "Stable" versions. If you are looking to test Half-Life: Enhanced to report bugs and/or you are not afraid of using a version that may contains bugs or crash on rare moments, then go ahead.</p>
+						<button type="button" class="btn btn-warning"><a href="#">Game - Coming soon</a></button>
+						<button type="button" class="btn btn-warning"><a href="#">Source code - Coming soon</a></button>
+					</div>
 				</div>
+
+				<p><!-- This is evil --></p>
+
+				<h2>Bleeding Edge</h2>
+				<p>If you want to get the very latest features and/or contribute to Half-Life: Enhanced, this is the version you should use. Keep in mind that this version is likely to contain a lot of bugs and eventually crash. If you are looking to create or upgrade your Half-Life 1 map or mod project, it's highly recommend to <b>NOT</b> use this version and switch to "Stable" or "Snapshot" instead.</p>
+				<button type="button" class="btn btn-danger"><a href="https://github.com/SamVanheer/HLEnhanced-Game">Game - GitHub</a></button>
+				<button type="button" class="btn btn-danger"><a href="https://github.com/SamVanheer/HLEnhanced">Source code - GitHub</a></button>
+
+				<p><!-- This is evil --></p>
 			</div>
+		</div>
 
-			<!-- Footer -->
-			<footer class="footer">
-				<div class="container">
-					<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
-					Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
-				</div>
-			</footer>
+		<!-- Footer -->
+		<footer class="footer">
+			<div class="container">
+				<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
+				Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
+			</div>
+		</footer>
 
-			<!-- Bootstrap 4 JS -->
-			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
-			<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
-			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+		<!-- Bootstrap 4 JS -->
+		<script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 	</body>
 </html>

--- a/index.htm
+++ b/index.htm
@@ -7,64 +7,67 @@
 		<meta http-equiv="X-UA-compatible" content="IE=edge">
 
 		<!-- Bootstrap 4 CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 		<link rel="stylesheet" href="design.css">
 
 		<title>Half-Life: Enhanced</title>
 	</head>
-		<body>
-
-			<!-- Navigation bar -->
-			<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
-				<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
-				<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-				<div class="collapse navbar-toggleable-md" id="navbarResponsive">
-					<ul class="nav navbar-nav">
-						<li class="nav-item active">
-							<a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="about.htm">About</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="downloads.htm">Downloads</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="documentation.htm">Documentation</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="social.htm">Social</a>
-						</li>
-					</ul>
-				</div>
-			</nav>
-
-			<!-- Breadcrumb -->
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item active">Home</li>
-			</ol>
-
-			<!-- Content -->
-			<div class="container">
-				<div class="starter-template">
-					<h1>Half-Life: Enhanced</h1>
-					<p class="lead">Welcome to the Half-Life: Enhanced website!</p>
-
-					<p>Want to contribute to this website? Feel free to help us by using the <a href="https://github.com/SamVanheer/HLEnhanced/tree/gh-pages">"GitHub Pages" branch</a> of <a href="https://github.com/SamVanheer/HLEnhanced/tree/gh-pages">Half-Life: Enhanced's GitHub</a> repository!</p>
-				</div>
+	<body>
+		<!-- Navigation bar -->
+		<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+			<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
+			<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
+			<div class="collapse navbar-toggleable-md" id="navbarResponsive">
+				<ul class="nav navbar-nav">
+					<li class="nav-item active">
+						<a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="about.htm">About</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="downloads.htm">Downloads</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="documentation.htm">Documentation</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="social.htm">Social</a>
+					</li>
+				</ul>
 			</div>
+		</nav>
 
-			<!-- Footer -->
-			<footer class="footer">
-				<div class="container">
-					<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
-					Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
-				</div>
-			</footer>
+		<!-- Breadcrumb -->
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item active">Home</li>
+		</ol>
 
-			<!-- Bootstrap 4 JS -->
-			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
-			<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
-			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+		<!-- Content -->
+		<div class="container">
+			<div class="starter-template">
+				<h1>Half-Life: Enhanced</h1>
+				<p class="lead">Welcome to the GitHub pages of Half-Life: Enhanced!</p>
+
+				<h2>Introduction</h2>
+				<p>Half-Life: Enhanced (not to be confused with the mod on ModDB) is a project that aims to improve the lives of modders and players of <a href="http://store.steampowered.com/app/70/">Half-Life 1</a>. Wanna learn more about it? Check out the <a href="about.htm">"About" page</a>.</p>
+
+				<h2>Contributions</h2>
+				<p>Want to contribute to the project itself or these pages? Feel free to do so by using the <a href="https://github.com/SamVanheer/HLEnhanced/tree/gh-pages">"GitHub Pages" branch</a> or the <a href="https://github.com/SamVanheer/HLEnhanced">"master" branch</a>. Any contribution even if it's small is welcome.</p>
+			</div>
+		</div>
+
+		<!-- Footer -->
+		<footer class="footer">
+			<div class="container">
+				<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.<br>
+				Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
+			</div>
+		</footer>
+
+		<!-- Bootstrap 4 JS -->
+		<script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 	</body>
 </html>

--- a/social.htm
+++ b/social.htm
@@ -7,78 +7,77 @@
 		<meta http-equiv="X-UA-compatible" content="IE=edge">
 
 		<!-- Bootstrap 4 CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/css/bootstrap.min.css" integrity="sha384-AysaV+vQoT3kOAXZkl02PThvDr8HYKPZhNT5h/CXfBThSRXQ6jW5DO2ekP5ViFdi" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
 		<link rel="stylesheet" href="design.css">
 
 		<title>Half-Life: Enhanced - Social</title>
 	</head>
-		<body>
+	<body>
+		<!-- Navigation bar -->
+		<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
+			<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
+			<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
+			<div class="collapse navbar-toggleable-md" id="navbarResponsive">
+				<ul class="nav navbar-nav">
+					<li class="nav-item">
+						<a class="nav-link" href="index.htm">Home</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="about.htm">About</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="downloads.htm">Downloads</a>
+					</li>
+					<li class="nav-item">
+						<a class="nav-link" href="documentation.htm">Documentation</a>
+					</li>
+					<li class="nav-item active">
+						<a class="nav-link" href="#">Social <span class="sr-only">(current)</span></a>
+					</li>
+				</ul>
+			</div>
+		</nav>
 
-			<!-- Navigation bar -->
-			<nav class="navbar navbar-fixed-top navbar-dark bg-inverse">
-				<a class="navbar-brand" href="#">Half-Life: Enhanced</a>
-				<button class="navbar-toggler hidden-lg-up" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"></button>
-				<div class="collapse navbar-toggleable-md" id="navbarResponsive">
-					<ul class="nav navbar-nav">
-						<li class="nav-item">
-							<a class="nav-link" href="index.htm">Home</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="about.htm">About</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="downloads.htm">Downloads</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="documentation.htm">Documentation</a>
-						</li>
-						<li class="nav-item active">
-							<a class="nav-link" href="#">Social <span class="sr-only">(current)</span></a>
-						</li>
-					</ul>
-				</div>
-			</nav>
+		<!-- Breadcrumb -->
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item active">Social</li>
+		</ol>
 
-			<!-- Breadcrumb -->
-			<ol class="breadcrumb">
-				<li class="breadcrumb-item active">Social</li>
-			</ol>
+		<!-- Content -->
+		<div class="container">
+			<div class="starter-template">
+				<h1>Social</h1>
+				<p class="lead">There are multiple ways to talk with Half-Life: Enhanced's developers.</p>
 
-			<!-- Content -->
-			<div class="container">
-				<div class="starter-template">
-					<h1>Social</h1>
-					<p class="lead">There are multiple ways to talk with Half-Life: Enhanced's developers.</p>
-
-					<div class="row">
-						<!-- Gitter -->
-						<div class="col-xs-6">
-							<a href="https://gitter.im/HLEnhanced-Project/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://d1qb2nb5cznatu.cloudfront.net/startups/i/368944-d81438d134dc6c5567ffaab69861cb34-medium_jpg.jpg?buster=1404125976" class="img-fluid" alt=""></a>
-							<p>Gitter</p>
-						</div>
-
-						<!-- The Whole Half-Life -->
-						<div class="col-xs-6">
-							<a href="http://twhl.info/forums.php?thread=19070&page=1"><img src="http://twhl.info/images/logo_final2.jpg" class="img-fluid" alt=""></a>
-							<p>The Whole Half-Life</p>
-						</div>
+				<div class="row">
+					<!-- Gitter -->
+					<div class="col-xs-6">
+						<a href="https://gitter.im/HLEnhanced-Project/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://d1qb2nb5cznatu.cloudfront.net/startups/i/368944-d81438d134dc6c5567ffaab69861cb34-medium_jpg.jpg?buster=1404125976" class="img-fluid" alt=""></a>
+						<p>Gitter</p>
 					</div>
 
-					<p>You want to add your own or other place to talk about Half-Life: Enhanced? Feel free to add it through GitHub!</p>
+					<!-- The Whole Half-Life -->
+					<div class="col-xs-6">
+						<a href="http://twhl.info/forums.php?thread=19070&page=1"><img src="http://twhl.info/images/logo_final2.jpg" class="img-fluid" alt=""></a>
+						<p>The Whole Half-Life</p>
+					</div>
 				</div>
+
+				<p>You want to add your own or other place to talk about Half-Life: Enhanced? Feel free to add it through GitHub!</p>
 			</div>
+		</div>
 
-			<!-- Footer -->
-			<footer class="footer">
-				<div class="container">
-					<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.
-					<br>Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
-				</div>
-			</footer>
+		<!-- Footer -->
+		<footer class="footer">
+			<div class="container">
+				<span class="text-muted">Powered by <a href="http://v4-alpha.getbootstrap.com/">Bootstrap V4</a>, hosted by <a href="https://pages.github.com/">GitHub Pages</a>.
+				<br>Half-Life is a trademarked property of <a href="http://www.valvesoftware.com/">Valve Corporation</a>.</span>
+			</div>
+		</footer>
 
-			<!-- Bootstrap 4 JS -->
-			<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
-			<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.3.7/js/tether.min.js" integrity="sha384-XTs3FgkjiBgo8qjEjBk0tGmf3wPrWtA6coPfQDfFEY8AnYJwjalXCiosYRBIBZX8" crossorigin="anonymous"></script>
-			<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.5/js/bootstrap.min.js" integrity="sha384-BLiI7JTZm+JWlgKa0M0kGRpJbF2J8q+qreVrKBC47e3K6BW78kGLrCkeRX6I9RoK" crossorigin="anonymous"></script>
+		<!-- Bootstrap 4 JS -->
+		<script src="https://code.jquery.com/jquery-3.1.1.slim.min.js" integrity="sha384-A7FZj7v+d/sdmMqp/nOQwliLvUsJfDHW+k9Omg/a/EheAdgtzNs3hpfag6Ed950n" crossorigin="anonymous"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js" integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb" crossorigin="anonymous"></script>
+		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/js/bootstrap.min.js" integrity="sha384-vBWWzlZJ8ea9aCX4pEW3rVHjgjt7zpkNpZk+02D9phzyeVkE+jo0ieGizqPLForn" crossorigin="anonymous"></script>
 	</body>
 </html>


### PR DESCRIPTION
- Add warning that online Doxygen docs could be outdated
- Add Gold Source Rebuild to the documentation page
- Add warning about WON/Xash3D on downloads page
- Add details on the about and index page
- Reworded some sentences
- Fix h3 tag closing a h2 tag on downloads page
- Fix bad code style
- Move hardcoded buttons text color to the CSS
- Update Bootstrap 4 to Alpha 6